### PR TITLE
npm install -D typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15422,6 +15422,12 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
+    "typescript": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.1.tgz",
+      "integrity": "sha512-3NSMb2VzDQm8oBTLH6Nj55VVtUEpe/rgkIzMir0qVoLyjDZlnMBva0U6vDiV3IH+sl/Yu6oP5QwsAQtHPmDd2Q==",
+      "dev": true
+    },
     "uglify-js": {
       "version": "3.4.10",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.10.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "not op_mini all"
   ],
   "devDependencies": {
-    "styled-components": "^4.1.3"
+    "styled-components": "^4.1.3",
+    "typescript": "^3.4.1"
   }
 }


### PR DESCRIPTION
# 目的
以下のエラーが発生していた。
```
npm ERR! peer dep missing: typescript@*, required by ts-pnp@1.0.1
```

依存関係にtypescriptが必要なpackageがあるが、typescriptが入っていなかっため追加する

# やったこと
- [x] npm install -D typescript
