### PR TITLE
frontのベースコンテナをnode:10.15.3-alpineに変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:11.12.0
+FROM node:10.15.3-alpine
 
 ENV TZ=Asia/Tokyo
 ENV LANG=C.UTF-8

--- a/package-lock.json
+++ b/package-lock.json
@@ -6499,8 +6499,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6537,8 +6536,7 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
@@ -6547,8 +6545,7 @@
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6651,8 +6648,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6662,7 +6658,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6675,20 +6670,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6705,7 +6697,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6778,8 +6769,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6789,7 +6779,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6865,8 +6854,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6896,7 +6884,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6914,7 +6901,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6953,13 +6939,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },


### PR DESCRIPTION
# 目的
nodeのバージョンは偶数番号がLTS、奇数番号が最新版となっている。
nodeの開発にコミットしたいわけでなくプロダクトで使えるようになることが目的のため、LTS版を利用する。

ついでにalplineコンテナにして軽量化した。
Railsの場合はgemがubuntuのライブラリに依存することも多く、alplineコンテナを利用すると大変なため利用していなかった。
React(node)はフロントエンドで実行するもののためテストやビルドが問題なければ使えるんじゃないかなと思ったため試してみる。

**変更前**
```
docker-sample_front     latest              99b46c5802e0        30 seconds ago      1.17GB
node                    10.15.3             64c810caf95a        6 days ago          899MB
```

**変更後**
```
docker-sample_front     latest              948c24eca09c        10 seconds ago      337MB
node                    10.15.3-alpine      94f3c8956482        3 weeks ago         71MB
```

テスト(jest)やbuildは動作しているため問題ないと思うが、運用して困ることが多いようならalpineコンテナの利用はやめる。

余談だがv12は2019年10月リリース予定らしい
https://github.com/nodejs/node/issues/25082

# 動作確認
- npm run build
- npm start
- npm test
